### PR TITLE
chore: tailwind 색상 토큰 정의

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,19 +1,24 @@
-import type { Config } from "tailwindcss"
+import type { Config } from "tailwindcss";
 
 const config = {
   darkMode: ["class"],
   content: [
-    './pages/**/*.{ts,tsx}',
-    './components/**/*.{ts,tsx}',
-    './app/**/*.{ts,tsx}',
-    './src/**/*.{ts,tsx}',
-	],
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
   prefix: "",
   theme: {
     container: {
       center: true,
       padding: "2rem",
       screens: {
+        mobile: "375px",
+        sm: "640px",
+        md: "768px",
+        lg: "1024px",
+        xl: "1280px",
         "2xl": "1400px",
       },
     },
@@ -22,15 +27,15 @@ const config = {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        background: "#1C1C1C",
+        foreground: "#1C1C1C",
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: "#5065FF",
+          foreground: "#3C3C3C",
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
+          DEFAULT: "#D5FF76",
+          foreground: "#3C3C3C",
         },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
@@ -41,7 +46,7 @@ const config = {
           foreground: "hsl(var(--muted-foreground))",
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
+          DEFAULT: "#FFFFFF",
           foreground: "hsl(var(--accent-foreground))",
         },
         popover: {
@@ -75,6 +80,6 @@ const config = {
     },
   },
   plugins: [require("tailwindcss-animate")],
-} satisfies Config
+} satisfies Config;
 
-export default config
+export default config;


### PR DESCRIPTION
# 📌 작업 내용



화면 넓이에 따른 반응형 웹 브레이크 포인트를 다음과 같이 정의합니다.

```
- mobile: 375px (figma 디자인 시 적용된 최저값을 적용하기 위한 mobile prfix 적용)
- sm: 640px 
- md: 768px
- lg: 1024px
- xl: 1280px
- 2xl: 1400px
```


프로젝트 테마 색상을 다음과 같이 정의합니다.

* primary: 트레이너 테마 컬러
* secondary: 회원 테마 컬러

```
- foreground: #1C1C1C
- background: #1C1C1C
- primary.default: #5065FF
- primary.foreground: #3C3C3C
- secondary.default:  #D5FF76
- secondary.foreground: #3C3C3C
```

# 🚦 특이 사항

---

> [!NOTE]
> 텍스트 관련은 추후 협의 후 재작성 및 코드 수정

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

- Ex) 함수 네이밍이 적절한지 검토해주세요!

<!-- close 할 이슈 번호 입력 -->

close #3
