### PR TITLE
chore: tailwind 색상 토큰 재정의

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,15 @@
 
 @layer base {
   :root {
+    --primary-trainer: #5065ff;
+    --primary-user: #d5ff76;
+    --main-bg: #1c1c1c;
+    --sub-bg: #3e3e3e;
+    --third-bg: #d9d9d9;
+    --main-text: #ffffff;
+    --sub-text: #9e9e9e;
+    --third-text: #262626;
+
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,6 +24,15 @@ const config = {
     },
     extend: {
       colors: {
+        "primary-trainer": "var(--primary-trainer)",
+        "primary-user": "var(--primary-user)",
+        "main-bg": "var(--main-bg)",
+        "sub-bg": "var(--sub-bg)",
+        "third-bg": "var(--third-bg)",
+        "main-text": "var(--main-text)",
+        "sub-text": "var(--sub-text)",
+        "third-text": "var(--third-text)",
+
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,15 +27,15 @@ const config = {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
-        background: "#1C1C1C",
-        foreground: "#1C1C1C",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
         primary: {
-          DEFAULT: "#5065FF",
-          foreground: "#3C3C3C",
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
         },
         secondary: {
-          DEFAULT: "#D5FF76",
-          foreground: "#3C3C3C",
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
         },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
@@ -46,7 +46,7 @@ const config = {
           foreground: "hsl(var(--muted-foreground))",
         },
         accent: {
-          DEFAULT: "#FFFFFF",
+          DEFAULT: "hsl(var(--accent))",
           foreground: "hsl(var(--accent-foreground))",
         },
         popover: {


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->

- 이전에 승현님이 작업해주신 tailwind 색상 토큰을 재정의하였습니다.
   - shadCN에서 자동으로 정의한 `global.css`와 `tailwind 색상토큰`은 초기 상태 그대로 두고, 저희가 직접 만든 토큰을 네이밍과 한칸 띄어쓰기로 구분 지었습니다.
   - 색상 토큰 네이밍이 적절한지 확인해주시면 감사하겠습니다.

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

<!-- close 할 이슈 번호 입력 -->

close #5 
