### PR TITLE
style: 일지 생성을 위해 createJournal 컴포넌트 구현

### DIFF
--- a/components/CreateJournal.tsx
+++ b/components/CreateJournal.tsx
@@ -57,7 +57,7 @@ function PTIcon() {
   return (
     <div>
       <Dumbbell size={25} color="#1C1C1C" />
-      <p className="mt-1 text-base font-bold text-third-text">식단</p>
+      <p className="mt-1 text-base font-bold text-third-text">PT</p>
     </div>
   );
 }

--- a/components/CreateJournal.tsx
+++ b/components/CreateJournal.tsx
@@ -1,0 +1,63 @@
+import { ButtonHTMLAttributes } from "react";
+import { Dumbbell, Plus, Utensils, Zap } from "lucide-react";
+
+interface CreateJournalProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  journalType: "exercise" | "diet" | "pt";
+}
+
+export default function CreateJournal({
+  journalType,
+  ...props
+}: CreateJournalProps) {
+  const getIconByJournalType = () => {
+    switch (journalType) {
+      case "exercise":
+        return <ExerciseIcon />;
+      case "diet":
+        return <DietIcon />;
+      case "pt":
+        return <PTIcon />;
+    }
+  };
+
+  return (
+    <div className="flex h-[130px] w-[164px] flex-col justify-between rounded-[30px] bg-primary-trainer p-5">
+      {getIconByJournalType()}
+      <div className="flex justify-end">
+        <button
+          {...props}
+          className="flex h-[35px] w-[35px] items-center justify-center rounded-[13px] bg-main-bg"
+        >
+          <Plus size={20} color="#5065ff" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ExerciseIcon() {
+  return (
+    <div>
+      <Zap size={25} color="#1C1C1C" />
+      <p className="mt-1 text-base font-bold text-third-text">운동</p>
+    </div>
+  );
+}
+
+function DietIcon() {
+  return (
+    <div>
+      <Utensils size={25} color="#1C1C1C" />
+      <p className="mt-1 text-base font-bold text-third-text">식단</p>
+    </div>
+  );
+}
+
+function PTIcon() {
+  return (
+    <div>
+      <Dumbbell size={25} color="#1C1C1C" />
+      <p className="mt-1 text-base font-bold text-third-text">식단</p>
+    </div>
+  );
+}


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->

<img width="341" alt="image" src="https://github.com/user-attachments/assets/97ee6167-ce9f-4fbc-b787-df7e8bb55e13">

### 트레이너와 회원이 `운동/식단/PT` 일지를 생성하기 위해 `createJournal` 컴포넌트를 구현하였습니다.

- 현재 디자인에는 나와있지 않지만 PT 일지를 위해 `PT Icon`도 추가를 해 두었습니다. 트레이너 도메인에서 해당 컴포넌트를 사용한다면 트레이너는 식단/운동 일지는 직접 작성하지 않으며 PT 일지만 작성하기 때문입니다.
- `journalType` prop을 통해 어떤 아이콘을 보여줄 지 이 컴포넌트를 사용하는 쪽에서 결정할 수 있으며, props로 어떤 아이콘이 들어올지 결정하는 것이 사용하는 입장에서 조금 더 직관적일 것 같아 props로 제어할 수 있도록 구현하였습니다.
- 아직 반응형 디자인이 나오지 않아 정적 디자인으로 구현이 되어있지만 추후 반응형 디자인이 나오면 그에 맞게 수정이 필요할 것 같습니다.
- 추가로 카카오 로그인 기능이 백엔드에서 완료가 되면, 권한 여부에 따라 해당 컴포넌트의 색상이 `trainer` 또는 `user` 색상으로 변환할 수 있도록 수정이 필요합니다.

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

- 컴포넌트의 네이밍과 함수네이밍이 적절한지 피드백 부탁드립니다.
- createJournal의 현재의 구조보다 더 나은 구조가 있다면 피드백 부탁드립니다.

<!-- close 할 이슈 번호 입력 -->

close #20 
