### PR TITLE
style: 메모 작성을 위한 TextareaWithLabel 컴포넌트 구현

### DIFF
--- a/components/TextareaWithLabel.tsx
+++ b/components/TextareaWithLabel.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { TextareaHTMLAttributes } from "react";
+
+interface TextareaWithLabelProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label: string;
+  id: string;
+  placeholder: string;
+  className?: string;
+}
+export function TextareaWithLabel({
+  label,
+  id,
+  placeholder,
+  className,
+  ...props
+}: TextareaWithLabelProps) {
+  return (
+    <div className={(cn("grid w-full gap-2"), className)}>
+      <Label htmlFor={id} className="text-[17px] text-main-text">
+        {label}
+      </Label>
+      <Textarea
+        placeholder={placeholder}
+        id={id}
+        className="h-full w-full resize-none rounded-[20px] bg-third-bg text-main-text"
+        {...props}
+      />
+    </div>
+  );
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/deeaff4a-afa7-44d6-adf6-dcd2574b8812">

### 메모 작성을 위한 TextareaWithLabel 컴포넌트 구현
회원과 트레이너의 피드백 또는 일지 작성 시 메모를 작성할 `TextareaWithLabel` 컴포넌트를 구현하였습니다.
- 사용하는 쪽에서 스타일을 수정할 수 있게 `className` props를 추가하였고, 나머지는 기본적인 `Textarea` 태그에서 사용할 수 있는 속성들을 Props로 주입해주었습니다.
- 실제 figma 디자인에는 메모 컴포넌트의 height가 269px로 지정 되어있지만 메모 컴포넌트가 차지하는 공간이 너무 큰 것 같아 일단 height를 `shadCN`의 기본 값으로 사용하였습니다.

> 아래 코드를 사용하여 컴포넌트를 테스트 해 보실 수 있습니다.
```tsx
import { TextareaWithLabel } from "@/components/TextareaWithLabel";

export default function User() {
  return (
    <TextareaWithLabel
      label="메모"
      id="memo"
      placeholder="메모를 작성하세요."
      className="h-32"
    />
  );
}

```
# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

- `TextareaWithLabel` 컴포넌트의 구성과 props 네이밍이 적절한지 피드백 부탁드립니다.

<!-- close 할 이슈 번호 입력 -->

close #24 
