### PR TITLE
style: DietItem 컴포넌트 및 더보기 버튼 클릭을 이용한 Action Sheets 구현

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-main-bg sm:w-full sm:flex-col md:w-full md:flex-col lg:w-full">
+    <main className="flex min-h-screen flex-col items-center justify-center bg-main-bg">
       <div className="flex-col">
         <div className="relative">
           <figure>

--- a/components/ActionSheet.tsx
+++ b/components/ActionSheet.tsx
@@ -1,11 +1,10 @@
-import React, { Dispatch, SetStateAction } from "react";
-import { Button } from "./ui/button";
+"use client";
 
-export type actionProps = {
-  name: string;
-  action: () => void;
-  type?: "danger" | "basic" | undefined;
-};
+import React, { useRef } from "react";
+import { Button } from "./ui/button";
+import { actionProps } from "@/types/actionSheet";
+import useOutsideClick from "@/hooks/useOutsideClick";
+
 interface ActionSheetProps {
   actions: actionProps[];
   closeAction: () => void;
@@ -14,13 +13,16 @@ export default function ActionSheet({
   actions,
   closeAction,
 }: ActionSheetProps) {
+  const actionsRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(actionsRef, closeAction);
+
   return (
     <div className="fixed left-0 top-0 flex h-full w-full">
+      <div className="flex h-full w-full bg-black opacity-40" />
       <div
-        className="flex h-full w-full bg-black opacity-40"
-        onClick={closeAction}
-      />
-      <div className="absolute bottom-3 flex w-full flex-col-reverse items-center justify-center">
+        ref={actionsRef}
+        className="animate-slide-up absolute bottom-3 flex w-full flex-col-reverse items-center justify-center duration-300"
+      >
         <Button
           className="h-[56px] w-11/12 items-center justify-center bg-[#25252588] p-3 text-[17px] text-[#0A84FF] backdrop-blur-sm hover:bg-[#303030]"
           onClick={closeAction}
@@ -28,19 +30,19 @@ export default function ActionSheet({
           취소
         </Button>
         <div className="relative bottom-3 w-11/12 items-center justify-center overflow-hidden rounded-[10px] backdrop-blur-sm">
-          {actions.map((action, index) => {
+          {actions.map(({ name, action, type }, index) => {
             return (
-              <div key={`action_${action.name}`}>
+              <div key={`action_${name}`}>
                 <Button
                   className="h-[56px] w-full rounded-none bg-[#25252588] text-[17px] text-white hover:bg-[#30303088]"
                   style={{
-                    color: action.type === "danger" ? "#FF453A" : "white",
+                    color: type === "danger" ? "#FF453A" : "white",
                   }}
                   onClick={() => {
-                    action.action();
+                    action();
                   }}
                 >
-                  {action.name}
+                  {name}
                 </Button>
                 {index < actions.length - 1 && (
                   <hr className="h-[1px] w-full border-[#80808070]" />

--- a/components/ActionSheet.tsx
+++ b/components/ActionSheet.tsx
@@ -1,0 +1,55 @@
+import React, { Dispatch, SetStateAction } from "react";
+import { Button } from "./ui/button";
+
+export type actionProps = {
+  name: string;
+  action: () => void;
+  type?: "danger" | "basic" | undefined;
+};
+interface ActionSheetProps {
+  actions: actionProps[];
+  closeAction: () => void;
+}
+export default function ActionSheet({
+  actions,
+  closeAction,
+}: ActionSheetProps) {
+  return (
+    <div className="fixed left-0 top-0 flex h-full w-full">
+      <div
+        className="flex h-full w-full bg-black opacity-40"
+        onClick={closeAction}
+      />
+      <div className="absolute bottom-3 flex w-full flex-col-reverse items-center justify-center">
+        <Button
+          className="h-[56px] w-11/12 items-center justify-center bg-[#25252588] p-3 text-[17px] text-[#0A84FF] backdrop-blur-sm hover:bg-[#303030]"
+          onClick={closeAction}
+        >
+          취소
+        </Button>
+        <div className="relative bottom-3 w-11/12 items-center justify-center overflow-hidden rounded-[10px] backdrop-blur-sm">
+          {actions.map((action, index) => {
+            return (
+              <div key={`action_${action.name}`}>
+                <Button
+                  className="h-[56px] w-full rounded-none bg-[#25252588] text-[17px] text-white hover:bg-[#30303088]"
+                  style={{
+                    color: action.type === "danger" ? "#FF453A" : "white",
+                  }}
+                  onClick={() => {
+                    action.action();
+                  }}
+                >
+                  {action.name}
+                </Button>
+                {index < actions.length - 1 && (
+                  <hr className="h-[1px] w-full border-[#80808070]" />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/DietItem.tsx
+++ b/components/DietItem.tsx
@@ -5,43 +5,26 @@ import imageSvg from "public/image.svg";
 import { Input } from "./ui/input";
 import { EllipsisVertical } from "lucide-react";
 import { useState } from "react";
-import ActionSheet, { actionProps } from "./ActionSheet";
+import { formatTime } from "@/utils/dateUtils";
+import ActionSheet from "./ActionSheet";
+import { actionProps } from "@/types/actionSheet";
 
 interface DietItemProps {
   src: string;
-  mealType: "아침" | "점심" | "저녁" | "간식" | "미입력";
+  mealType: "아침" | "점심" | "저녁" | "간식";
   mealTime: Date;
-  mealWeight: "가볍게" | "적당히" | "무겁게" | "미입력";
-  mealMass: number;
+  mealAmount: "가볍게" | "적당히" | "무겁게";
+  mealWeight: number;
   calorie: number;
 }
 
-function formatTime(date: Date): string {
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
-
-  const period = hours >= 12 ? "오후" : "오전";
-  const formattedHours = (hours % 12 || 12).toString().padStart(2, "0"); // 0 시를 12 시로 표현하고 두 자리로 포맷
-  const formattedMinutes = minutes.toString().padStart(2, "0");
-
-  return `${period} ${formattedHours}:${formattedMinutes}`;
-}
-
-/**
- * @param {string} src - 이미지 경로
- * @param {"아침" | "점심" | "저녁" | "간식"} mealTime - 식사 시간을 나타내는 명사
- * @param {string} dateTime - 식사 시간 (타임스탬프 등)
- * @param {string} mealWeight - 식사량을 나타내는 텍스트
- * @param {number} mealMass - 식사의 무게 (그램 등)
- * @param {number} calorie - 식사의 칼로리
- */
 export default function DietItem({
   src,
-  mealType = "미입력",
+  mealType,
   mealTime = new Date(),
-  mealWeight = "미입력",
-  mealMass = 0,
-  calorie = 0,
+  mealAmount,
+  mealWeight,
+  calorie,
 }: DietItemProps) {
   const [statusAction, setStatusAction] = useState(false);
 
@@ -79,7 +62,7 @@ export default function DietItem({
   return (
     <>
       <div className="flex h-[219px] w-full justify-center p-3 text-white">
-        <div className="h-1/1 flex aspect-square w-[200px] items-center justify-center rounded-[10px] bg-[#D9D9D9]">
+        <div className="min-h-[200px]h-1/1 flex aspect-square min-w-[200px] items-center justify-center rounded-[10px] bg-[#D9D9D9]">
           <Image
             src={src ? src : imageSvg}
             alt="Image"
@@ -87,26 +70,26 @@ export default function DietItem({
             height={72}
           />
         </div>
-        <div className="h-1/1 ml-[12px] flex min-w-[168px] flex-col justify-between">
+        <div className="h-1/1 ml-[12px] flex w-full min-w-[168px] flex-col justify-between">
           <article>
             <span className="text-[17px]">{mealType}</span>
             <br />
-            <span className="text-[13px] text-[#9E9E9E]">
-              {`${formatTime(mealTime)}`} ㆍ {mealWeight}
+            <span className="text-[13px] text-sub-text">
+              {`${formatTime(mealTime)}`} ㆍ {mealAmount}
             </span>
             <br />
-            <span className="text-[13px] text-[#9E9E9E]">
-              {`${mealMass}g / ${calorie}kcal `}
+            <span className="text-[13px] text-sub-text">
+              {`${mealWeight}g / ${calorie}kcal `}
             </span>
           </article>
           <Input
-            className="rounded-[10px] border-[#9E9E9E] bg-[#1E1E1E] text-[15px] placeholder:text-center placeholder:text-[#9E9E9E]"
+            className="rounded-[10px] border-sub-text bg-[#1E1E1E] text-[15px] placeholder:text-center placeholder:text-sub-text"
             placeholder="피드백을 남겨주세요"
           />
         </div>
 
         <EllipsisVertical
-          className="text-[#9E9E9E]"
+          className="text-sub-text"
           size={30}
           onClick={openAction}
         />

--- a/components/DietItem.tsx
+++ b/components/DietItem.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Image from "next/image";
+import imageSvg from "public/image.svg";
+import { Input } from "./ui/input";
+import { EllipsisVertical } from "lucide-react";
+import { useState } from "react";
+import ActionSheet, { actionProps } from "./ActionSheet";
+
+interface DietItemProps {
+  src: string;
+  mealType: "아침" | "점심" | "저녁" | "간식" | "미입력";
+  mealTime: Date;
+  mealWeight: "가볍게" | "적당히" | "무겁게" | "미입력";
+  mealMass: number;
+  calorie: number;
+}
+
+function formatTime(date: Date): string {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  const period = hours >= 12 ? "오후" : "오전";
+  const formattedHours = (hours % 12 || 12).toString().padStart(2, "0"); // 0 시를 12 시로 표현하고 두 자리로 포맷
+  const formattedMinutes = minutes.toString().padStart(2, "0");
+
+  return `${period} ${formattedHours}:${formattedMinutes}`;
+}
+
+/**
+ * @param {string} src - 이미지 경로
+ * @param {"아침" | "점심" | "저녁" | "간식"} mealTime - 식사 시간을 나타내는 명사
+ * @param {string} dateTime - 식사 시간 (타임스탬프 등)
+ * @param {string} mealWeight - 식사량을 나타내는 텍스트
+ * @param {number} mealMass - 식사의 무게 (그램 등)
+ * @param {number} calorie - 식사의 칼로리
+ */
+export default function DietItem({
+  src,
+  mealType = "미입력",
+  mealTime = new Date(),
+  mealWeight = "미입력",
+  mealMass = 0,
+  calorie = 0,
+}: DietItemProps) {
+  const [statusAction, setStatusAction] = useState(false);
+
+  const openAction = (): void => {
+    setStatusAction(true);
+  };
+  const closeAction = (): void => {
+    setStatusAction(false);
+  };
+
+  const actions: Array<actionProps> = [
+    {
+      name: "공유",
+      action: () => {
+        closeAction();
+      },
+      type: "basic",
+    },
+    {
+      name: "수정",
+      action: () => {
+        closeAction();
+      },
+      type: "basic",
+    },
+    {
+      name: "삭제",
+      action: () => {
+        closeAction();
+      },
+      type: "danger",
+    },
+  ];
+
+  return (
+    <>
+      <div className="flex h-[219px] w-full justify-center p-3 text-white">
+        <div className="h-1/1 flex aspect-square w-[200px] items-center justify-center rounded-[10px] bg-[#D9D9D9]">
+          <Image
+            src={src ? src : imageSvg}
+            alt="Image"
+            width={72}
+            height={72}
+          />
+        </div>
+        <div className="h-1/1 ml-[12px] flex min-w-[168px] flex-col justify-between">
+          <article>
+            <span className="text-[17px]">{mealType}</span>
+            <br />
+            <span className="text-[13px] text-[#9E9E9E]">
+              {`${formatTime(mealTime)}`} ㆍ {mealWeight}
+            </span>
+            <br />
+            <span className="text-[13px] text-[#9E9E9E]">
+              {`${mealMass}g / ${calorie}kcal `}
+            </span>
+          </article>
+          <Input
+            className="rounded-[10px] border-[#9E9E9E] bg-[#1E1E1E] text-[15px] placeholder:text-center placeholder:text-[#9E9E9E]"
+            placeholder="피드백을 남겨주세요"
+          />
+        </div>
+
+        <EllipsisVertical
+          className="text-[#9E9E9E]"
+          size={30}
+          onClick={openAction}
+        />
+      </div>
+      {statusAction && (
+        <ActionSheet actions={actions} closeAction={closeAction} />
+      )}
+    </>
+  );
+}

--- a/public/image.svg
+++ b/public/image.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-image"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>

--- a/types/actionSheet.ts
+++ b/types/actionSheet.ts
@@ -1,0 +1,5 @@
+export type actionProps = {
+  name: string;
+  action: () => void;
+  type?: "danger" | "basic";
+};

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -41,3 +41,14 @@ export const getDaysInMonthForYearAndMonth = (year: number, month: number) => {
 
   return getDaysInMonth(date);
 };
+
+export const formatTime = (date: Date) => {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  const period = hours >= 12 ? "오후" : "오전";
+  const formattedHours = (hours % 12 || 12).toString().padStart(2, "0");
+  const formattedMinutes = minutes.toString().padStart(2, "0");
+
+  return `${period} ${formattedHours}:${formattedMinutes}`;
+};


### PR DESCRIPTION
# 📌 작업 내용

DietItem 컴포넌트와 더보기 아이콘을 클릭하여 액션 시트 컴포넌트 구현

<img width="539" alt="스크린샷 2024-08-17 오후 8 44 02" src="https://github.com/user-attachments/assets/49b36d10-7fec-42b1-92b6-aa11f971ea66">

<img width="546" alt="스크린샷 2024-08-17 오후 8 44 15" src="https://github.com/user-attachments/assets/8eda2937-a994-4c81-b470-d77b2359eaef">


📄 page.tsx에 다음 코드를 추가 후 테스트해 볼 수 있습니다.
(page.tsx의 className에 flex-col값을 추가하면 가로로 배열하여 볼 수 있습니다.)
```typescript
      <DietItem
        src={""}
        mealType="아침"
        mealTime={new Date()}
        mealAmount="가볍게"
        mealWeight={200}
        calorie={140}
      />
      <DietItem
        src={""}
        mealType="점심"
        mealTime={new Date()}
        mealAmount="가볍게"
        mealWeight={200}
        calorie={140}
      />
      <DietItem
        src={""}
        mealType="간식"
        mealTime={new Date()}
        mealAmount="가볍게"
        mealWeight={200}
        calorie={140}
      />
      <DietItem
        src={""}
        mealType="저녁"
        mealTime={new Date()}
        mealAmount="가볍게"
        mealWeight={200}
        calorie={140}
      />
```

# 🚦 특이 사항

✅ DietItem에 Props 네이밍이 적절한지 확인 부탁드립니다.
✅ ActionSheets의 동작방식 및 구현방식이 적절한지 확인 부탁드립니다.

close #26
