### PR TITLE
style: 메인페이지에서 선택된 날짜를 일지 작성 페이지에서 보여주기 위한 DateViewer 컴포넌트 구현

### DIFF
--- a/components/DateViewer.tsx
+++ b/components/DateViewer.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+import { Badge } from "./ui/badge";
+import { HTMLAttributes } from "react";
+
+interface DateViewerProps extends HTMLAttributes<HTMLDivElement> {
+  date: Date;
+  className?: string;
+}
+
+export default function DateViewer({
+  date = new Date(),
+  className,
+  ...props
+}: DateViewerProps) {
+  const getYearMonthDay = () => {
+    return date.toISOString().split("T")[0].replace(/-/g, ".");
+  };
+
+  return (
+    <div className={cn("flex items-center gap-5", className)}>
+      <p>운동 날짜</p>
+      <Badge
+        className="flex h-[34px] w-[118px] items-center justify-center rounded-md bg-third-bg text-[17px] text-primary-trainer"
+        {...props}
+      >
+        {getYearMonthDay()}
+      </Badge>
+    </div>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-300",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
+        secondary:
+          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
+        destructive:
+          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80",
+        outline: "text-slate-950 dark:text-slate-50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->
<img width="203" alt="image" src="https://github.com/user-attachments/assets/b1c1f7d1-93e4-4885-9e71-4a3846422232">

### 메인페이지에서 선택된 날짜를 일지 작성 페이지에서 보여주기 위한 DateViewer 컴포넌트 구현
- shadCN의 Badge 컴포넌트를 install하고, 이를 활용하여 선택된 날짜를 `회원/트레이너`의 일지 작성 페이지에서 보여주기 위한 DateViewer 컴포넌트를 구현하였습니다.
- 디자인에는 시, 분까지 나와있지만 너무 디테일한 내용인 것 같아서 일단은 제거 후 작성하였습니다. 해당 부분은 디자이너분과 다시 회의한 뒤 결정하면 좋을 것 같습니다!

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

## ‼️ 컴포넌트 사용 X 폐기된 컴포넌트 ‼️

<!-- close 할 이슈 번호 입력 -->

close #29 
