### PR TITLE
style: 운동 일지 작성에 포함되는 운동 종목, 칼로리, 사진/영상, 메모를 포함하는 `WriteJournal` 컴포넌트 구현

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,7 +11,7 @@
     --primary-trainer: #5065ff;
     --primary-user: #d5ff76;
     --main-bg: #1c1c1c;
-    --sub-bg: #252525;
+    --sub-bg: #303030;
     --third-bg: #3e3e3e;
     --fourth-bg: #d9d9d9;
     --main-text: #ffffff;
@@ -75,4 +75,4 @@
   input[type="file"] {
     text-indent: -9999px;
   }
-} 
+}

--- a/components/InputWithLabel.tsx
+++ b/components/InputWithLabel.tsx
@@ -1,23 +1,23 @@
 "use client";
 
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import UseMediaFileUpload from "@/hooks/useMediaFileUpload";
-import { cn } from "@/lib/utils";
-import { FolderDown } from "lucide-react";
-import Image from "next/image";
 import {
   HTMLInputTypeAttribute,
   InputHTMLAttributes,
   ReactNode,
   useRef,
 } from "react";
+import { FolderDown } from "lucide-react";
+import Image from "next/image";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import UseMediaFileUpload from "@/hooks/useMediaFileUpload";
+import { cn } from "@/lib/utils";
 
 interface InputWithLabelProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   id: string;
   type?: HTMLInputTypeAttribute;
-  placeholder: string;
+  placeholder?: string;
   children?: ReactNode;
   styleProps?: {
     containerClassName?: string;
@@ -61,7 +61,7 @@ export default function InputWithLabel({
           ref={inputRef}
           placeholder={placeholder}
           className={cn(
-            "z-10 h-[46px] rounded-[10px] bg-transparent text-main-text",
+            "z-10 h-[46px] rounded-[10px] bg-sub-bg text-main-text",
             type === "file" && "h-full",
             (imageFile || videoFile) && "hidden",
             inputClassName,

--- a/components/TextareaWithLabel.tsx
+++ b/components/TextareaWithLabel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { TextareaHTMLAttributes } from "react";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { TextareaHTMLAttributes } from "react";
 
 interface TextareaWithLabelProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -20,14 +20,14 @@ export function TextareaWithLabel({
   ...props
 }: TextareaWithLabelProps) {
   return (
-    <div className={(cn("grid w-full gap-2"), className)}>
+    <div className={cn("flex w-full flex-col gap-2", className)}>
       <Label htmlFor={id} className="text-[17px] text-main-text">
         {label}
       </Label>
       <Textarea
         placeholder={placeholder}
         id={id}
-        className="h-full w-full resize-none rounded-[20px] bg-third-bg text-main-text"
+        className="h-full w-full resize-none rounded-[20px] bg-sub-bg text-main-text"
         {...props}
       />
     </div>

--- a/components/WriteJournal.tsx
+++ b/components/WriteJournal.tsx
@@ -1,0 +1,39 @@
+import { Search, ImagePlus } from "lucide-react";
+
+import InputWithLabel from "./InputWithLabel";
+import { TextareaWithLabel } from "./TextareaWithLabel";
+
+export default function WriteJournal() {
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <InputWithLabel
+        label="운동"
+        id="exercise"
+        placeholder="클릭하여 운동 종목+세트수+횟수를 설정하세요"
+      >
+        <Search className="absolute right-3 z-10" />
+      </InputWithLabel>
+      <InputWithLabel
+        label="칼로리"
+        id="kcal"
+        placeholder="운동하며 소모한 칼로리를 입력하세요"
+      >
+        <span className="absolute right-3 z-10">kcal</span>
+      </InputWithLabel>
+      <InputWithLabel
+        label="사진, 영상"
+        id="media"
+        type="file"
+        styleProps={{ inputClassName: "h-[266px]" }}
+      >
+        <ImagePlus className="absolute z-10" />
+      </InputWithLabel>
+      <TextareaWithLabel
+        label="메모"
+        id="memo"
+        placeholder="메모를 작성하세요."
+        className="h-[266px]"
+      />
+    </div>
+  );
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          "flex h-10 w-full rounded-md bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
           className,
         )}
         ref={ref}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
@@ -10,15 +10,15 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
-          className
+          "flex min-h-[80px] w-full rounded-md bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          className,
         )}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Textarea.displayName = "Textarea"
+    );
+  },
+);
+Textarea.displayName = "Textarea";
 
-export { Textarea }
+export { Textarea };


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->

## 일지에 작성 될 운동 종목, 사용한 칼로리, 운동 사진/영상, 메모를 포함하는 `WriteJournal` 컴포넌트 구현

<img width="220" alt="image" src="https://github.com/user-attachments/assets/adcb8eab-a5f8-4d42-b558-fe72dac25464">

- 해당 컴포넌트는 변경의 여지가 많기에 인터랙션에 대한 부분은 추후에 추가 하는 게 좋을 것 같아 이벤트 핸들러 없이 컴포넌트 style만 구현해두었습니다.

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

- 해당 컴포넌트의 네이밍이 적절한지 피드백 부탁드립니다 :)

<!-- close 할 이슈 번호 입력 -->

close #31
