### PR TITLE
style: 운동 일지에서 사진/영상 정보를 뺀 나머지 정보를 나타내는 `Exercise` 컴포넌트 구현

### DIFF
--- a/components/ExerciseRecord.tsx
+++ b/components/ExerciseRecord.tsx
@@ -1,0 +1,36 @@
+import { EllipsisVertical } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Badge } from "./ui/badge";
+
+export default function ExerciseRecord() {
+  return (
+    <Card className="relative flex w-full flex-col gap-3 rounded-[20px] border-none bg-primary-trainer p-4">
+      <EllipsisVertical className="absolute right-1 top-2" />
+      <div className="flex gap-3 px-1">
+        <p className="font-bold">120분</p>
+        <Badge>PT</Badge>
+        <Badge variant={"outline"}>400 kcal</Badge>
+      </div>
+      <div className="flex flex-col px-1">
+        <div className="flex gap-2">
+          <p className="font-bold">원레드 데드리프트</p>
+          <p>3set / 20</p>
+        </div>
+        <div className="flex gap-2">
+          <p className="font-bold">스쿼트</p>
+          <p>3set / 20</p>
+        </div>
+        <div className="flex gap-2">
+          <p className="font-bold">레그프레스</p>
+          <p>3set / 20</p>
+        </div>
+      </div>
+      <div className="w-full border border-sub-text"></div>
+      <div>
+        <pre className="h-full w-full rounded-[20px] px-1">
+          {"호흡은 수축할 때\n내쉬고 이완할 때 마시고\n코어 잘 잡고 운동하기"}
+        </pre>
+      </div>
+    </Card>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-300",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
+        secondary:
+          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
+        destructive:
+          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80",
+        outline: "text-slate-950 dark:text-slate-50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->
## 운동 일지에서 사진/영상 정보를 뺀 나머지 정보를 나타내는 `Exercise` 컴포넌트 구현하였습니다.

<img width="375" alt="image" src="https://github.com/user-attachments/assets/fe8799e6-14ed-40b7-b125-cb7d72291b94">

- 아직 백엔드와 회의가 이루어지지 않아 어떤 데이터가 어떻게 넘어올지 모르고, 우측 상단의 편집 버튼도 어떤 정보를 어떻게 바꿀것인지에 대한 디자인이 나오지 않아서 데이터를 하드하게 집어넣기만 하였습니다.
- 추후 백엔드 + 디자이너와 협의가 이루어지면 인터랙션 작업을 진행 할 예정입니다.

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

<!-- close 할 이슈 번호 입력 -->

close #33