### PR TITLE
style: 유저가 운동 종목에 해당하는 세트수, 무게, 반복수를 입력할 수 있는 ExerciseDetailsEditor 컴포넌트 구현

### DIFF
--- a/components/ExerciseDetailsEditor.tsx
+++ b/components/ExerciseDetailsEditor.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { ChangeEvent, useState } from "react";
+import { X } from "lucide-react";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+
+export default function ExerciseDetailsEditor() {
+  const [exerciseDetails, setExerciseDetails] = useState([
+    {
+      set: 1,
+      weight: "",
+      reps: "",
+    },
+  ]);
+
+  const handleClickAddSet = () => {
+    setExerciseDetails((prev) => [
+      ...prev,
+      {
+        set: prev.length + 1,
+        weight: "",
+        reps: "",
+      },
+    ]);
+  };
+
+  const handleChangeWeightAndReps = (
+    event: ChangeEvent<HTMLInputElement>,
+    detailType: "weight" | "reps",
+    index: number,
+  ) => {
+    const exerciseDetailsCopy = [...exerciseDetails];
+    exerciseDetailsCopy[index][detailType] = event.target.value;
+
+    setExerciseDetails(exerciseDetailsCopy);
+  };
+
+  const handleClickDeleteSet = (index: number) => {
+    const exerciseDetailsCopy = exerciseDetails.filter(
+      (_, idx) => idx !== index,
+    );
+
+    setExerciseDetails(exerciseDetailsCopy);
+  };
+
+  return (
+    <div className="w-full rounded-[10px] bg-primary-user p-3 text-third-text">
+      <div className="flex flex-col items-center justify-center">
+        {exerciseDetails.map(({ set, weight, reps }, index) => (
+          <div key={`${set}-${index}`} className="flex items-center gap-3">
+            <div className="flex w-14 justify-center font-bold">{set} 세트</div>
+            <Input
+              className="w-[90px] rounded-[10px] bg-third-bg text-right text-main-text"
+              placeholder="kg"
+              value={weight}
+              onChange={(event) =>
+                handleChangeWeightAndReps(event, "weight", index)
+              }
+            />
+            <Input
+              className="w-[90px] rounded-[10px] bg-third-bg text-right text-main-text"
+              placeholder="회"
+              value={reps}
+              onChange={(event) =>
+                handleChangeWeightAndReps(event, "reps", index)
+              }
+            />
+            <X
+              size={20}
+              strokeWidth={2.5}
+              onClick={() => handleClickDeleteSet(index)}
+            />
+          </div>
+        ))}
+      </div>
+      <Button
+        className="mt-2 h-[46px] w-full rounded-[10px] bg-third-bg"
+        onClick={handleClickAddSet}
+      >
+        세트 추가
+      </Button>
+    </div>
+  );
+}

--- a/components/ExerciseDetailsEditor.tsx
+++ b/components/ExerciseDetailsEditor.tsx
@@ -2,6 +2,7 @@
 
 import { ChangeEvent, useState } from "react";
 import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 
@@ -48,7 +49,10 @@ export default function ExerciseDetailsEditor() {
     <div className="w-full rounded-[10px] bg-primary-user p-3 text-third-text">
       <div className="flex flex-col items-center justify-center">
         {exerciseDetails.map(({ set, weight, reps }, index) => (
-          <div key={`${set}-${index}`} className="flex items-center gap-3">
+          <div
+            key={`${set}-${index}`}
+            className="flex items-center justify-center gap-3"
+          >
             <div className="flex w-14 justify-center font-bold">{set} 세트</div>
             <Input
               className="w-[90px] rounded-[10px] bg-third-bg text-right text-main-text"
@@ -70,6 +74,9 @@ export default function ExerciseDetailsEditor() {
               size={20}
               strokeWidth={2.5}
               onClick={() => handleClickDeleteSet(index)}
+              className={cn(
+                index !== exerciseDetails.length - 1 && "invisible",
+              )}
             />
           </div>
         ))}


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c26baf31-8632-4928-8396-ffb652f3eeb4">

## 유저가 운동 종목에 해당하는 세트수, 무게, 반복수를 입력할 수 있는 ExerciseDetailsEditor 컴포넌트 구현
- [x] 전체 세트수와 무게, 반복수를 하나의 state로 관리하고 있습니다.
- [x] 세트 추가 버튼을 누르면 하나의 세트가 추가됩니다.
- [x] 리렌더링을 최소화하기 위해 비제어 컴포넌트 방식으로 핸들링 하는 방법을 고민해 보았으나, 해당 컴포넌트는 실시간으로 동적인 인터랙션이 있기 때문에 제어 컴포넌트 방식으로 state로 관리하도록 구현하였습니다.

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

- 컴포넌트 명, 함수명이 올바른지 피드백 부탁드립니다.

<!-- close 할 이슈 번호 입력 -->

close #37 
