### PR TITLE
feat: 로그인 시 회원 유형에 따라 로컬 스토리지에 회원 유형 저장 기능 구현

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { MainLogo } from "@/components/MainLogo";
-import { Button } from "@/components/ui/button";
+import UserTypeSelection from "@/components/UserTypeSelection";
 
 export default function Home() {
   return (
@@ -10,15 +10,7 @@ export default function Home() {
             <MainLogo />
           </figure>
         </div>
-
-        <section>
-          <Button className="mt-[14px] h-[57px] w-full rounded-[18px] bg-primary-user text-[17px] font-bold text-black">
-            회원으로 로그인
-          </Button>
-          <Button className="mt-[14px] h-[57px] w-full rounded-[18px] bg-primary-trainer p-3 text-[17px] font-bold text-white">
-            트레이너로 로그인
-          </Button>
-        </section>
+        <UserTypeSelection />
       </div>
     </main>
   );

--- a/components/ActionSheet.tsx
+++ b/components/ActionSheet.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import React, { useRef } from "react";
-import { Button } from "./ui/button";
-import { actionProps } from "@/types/actionSheet";
+import { ActionProps } from "@/types/actionSheet";
 import useOutsideClick from "@/hooks/useOutsideClick";
+import { Button } from "./ui/button";
 
 interface ActionSheetProps {
-  actions: actionProps[];
+  actions: ActionProps[];
   closeAction: () => void;
 }
 export default function ActionSheet({
@@ -21,7 +21,7 @@ export default function ActionSheet({
       <div className="flex h-full w-full bg-black opacity-40" />
       <div
         ref={actionsRef}
-        className="animate-slide-up absolute bottom-3 flex w-full flex-col-reverse items-center justify-center duration-300"
+        className="absolute bottom-3 flex w-full animate-slide-up flex-col-reverse items-center justify-center duration-300"
       >
         <Button
           className="h-[56px] w-11/12 items-center justify-center bg-[#25252588] p-3 text-[17px] text-[#0A84FF] backdrop-blur-sm hover:bg-[#303030]"

--- a/components/DietItem.tsx
+++ b/components/DietItem.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Image from "next/image";
-import imageSvg from "public/image.svg";
-import { Input } from "./ui/input";
-import { EllipsisVertical } from "lucide-react";
 import { useState } from "react";
+import Image from "next/image";
+import { EllipsisVertical } from "lucide-react";
+import imageSvg from "public/image.svg";
 import { formatTime } from "@/utils/dateUtils";
+import { ActionProps } from "@/types/actionSheet";
+import { Input } from "./ui/input";
 import ActionSheet from "./ActionSheet";
-import { actionProps } from "@/types/actionSheet";
 
 interface DietItemProps {
   src: string;
@@ -35,7 +35,7 @@ export default function DietItem({
     setStatusAction(false);
   };
 
-  const actions: Array<actionProps> = [
+  const actions: Array<ActionProps> = [
     {
       name: "공유",
       action: () => {

--- a/components/UserTypeSelection.tsx
+++ b/components/UserTypeSelection.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useStorageStore } from "@/stores/useStorageStore";
+import { UserType } from "@/types/user";
+import { Button } from "./ui/button";
+
+export default function UserTypeSelection() {
+  const setUserType = useStorageStore((state) => state.setUserType);
+
+  const handleClickSetUserType = (userType: UserType) => {
+    setUserType(userType);
+  };
+
+  return (
+    <section>
+      <Button
+        className="mt-[14px] h-[57px] w-full rounded-[18px] bg-primary-user text-[17px] font-bold text-black"
+        onClick={() => handleClickSetUserType("Member")}
+      >
+        회원으로 로그인
+      </Button>
+      <Button
+        className="mt-[14px] h-[57px] w-full rounded-[18px] bg-primary-trainer p-3 text-[17px] font-bold text-white"
+        onClick={() => handleClickSetUserType("Trainer")}
+      >
+        트레이너로 로그인
+      </Button>
+    </section>
+  );
+}

--- a/stores/useStorageStore.ts
+++ b/stores/useStorageStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { UserType } from "@/types/user";
+
+interface StorageStateType {
+  userType: string;
+  setUserType: (userType: UserType) => void;
+}
+
+export const useStorageStore = create<StorageStateType>()(
+  persist(
+    (set) => ({
+      userType: "",
+      setUserType: (userType: "Member" | "Trainer") =>
+        set({ userType: userType }),
+    }),
+    {
+      name: "UserType",
+    },
+  ),
+);

--- a/types/actionSheet.ts
+++ b/types/actionSheet.ts
@@ -1,4 +1,4 @@
-export type actionProps = {
+export type ActionProps = {
   name: string;
   action: () => void;
   type?: "danger" | "basic";

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,1 @@
+export type UserType = "Member" | "Trainer";


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->

## 로그인 시 회원 유형에 따라 로컬 스토리지에 회원 유형 저장 기능 구현
<img width="300" alt="image" src="https://github.com/user-attachments/assets/96676661-88db-4ce6-8994-58e38cad67db">
<p>

- [x] 서비스를 진입 하는 페이지에서 유저가 어떤 유형인지(회원/트레이너) 버튼을 클릭하여 선택하는데 이때 유저의 유형을 `로컬 스토리지`에 저장하는 기능을 구현하였습니다.
- [x] zustand의 middleware인 `persist`를 사용하여 구현하였으며 이는 `store/useStorageSotre`에 위치 시켰습니다. 
- [x] 기존에 존재하던 `types/actionSheet`의 타입 네이밍을 `PascalCase`로 변경하였습니다.

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

- 현재 서비스를 진입 하는 페이지의 `page.tsx`에 유저의 유형을 결정하는 버튼이 구현 되어있고 버튼 인터랙션을 넣게 되면 해당 페이지는 CSR 방식으로 렌더링하게됩니다. 따라서 해당 페이지를 SSR 방식으로 렌더링하기 위해 해당 버튼을 따로 분리하여 구현하였습니다.
- 분리시킨 버튼 컴포넌트의 네이밍이 적절한지 피드백 부탁드립니다.
- 로컬스토리지를 핸들링하는 모듈이 `store/useStorageStore`에 위치하고 있는데, 해당 위치가 적절한 위치인지 피드백 부탁드립니다. 해당 네이밍은 **웹 스토리지를 관리한다**는 의미로 작성하였는데 정작 유저의 정보를 저장하고있어 목적과 파일의 네이밍이 일관성이 있는지 의문이 듭니다. 유저의 정보를 저장하는 만큼 유저 관련 네이밍으로 짓는게 적절할지, 웹 스토리지를 핸들링 하는 만큼 웹 스토리지 관련 핸들러만 관리하도록 지금처럼 네이밍을 유지할지 피드백 부탁드립니다.

<!-- close 할 이슈 번호 입력 -->

close #43 
