### PR TITLE
style: 부모 컴포넌트에서 공통으로 넘어오는 값을 이용하여 한 주를 나타내는 WeeklyCalnedar 컴포넌트 구현

### DIFF
--- a/components/JournalWeeklyCalendar.tsx
+++ b/components/JournalWeeklyCalendar.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils";
+
 interface JournalWeeklyCalendarProps {
   today: Date;
   selectedDate: Date;
@@ -45,7 +47,10 @@ export default function JournalWeeklyCalendar({
           return (
             <p
               key={`${day.key}OfWeek`}
-              className={`leading-7 ${isWeekend ? "text-sub-text" : "text-main-text"}`}
+              className={cn(
+                "leading-7 text-main-text",
+                isWeekend && "text-sub-text",
+              )}
             >
               {day.day}
             </p>
@@ -64,7 +69,13 @@ export default function JournalWeeklyCalendar({
             >
               <div
                 tabIndex={0}
-                className={`bold mt-[20px] flex h-9 w-9 cursor-pointer items-center justify-center rounded-md leading-7 transition-all duration-200 hover:bg-main-text hover:text-[#000] hover:transition ${date.getDate() === today.getDate() && "text-red-500 focus:text-[#000]"} ${selectedDate.getDate() === date.getDate() && "bg-white text-[#000] focus:text-[#000]"}`}
+                className={cn(
+                  "bold mt-[20px] flex h-9 w-9 cursor-pointer items-center justify-center rounded-md leading-7 transition-all duration-200 hover:bg-main-text hover:text-[#000] hover:transition",
+                  selectedDate.getDate() === date.getDate() &&
+                    "bg-white text-[#000]",
+                  date.getDate() === today.getDate() &&
+                    "text-red-500 hover:text-[#000]",
+                )}
               >
                 {date.getDate()}
               </div>

--- a/components/JournalWeeklyCalendar.tsx
+++ b/components/JournalWeeklyCalendar.tsx
@@ -1,3 +1,4 @@
+import { COUNT_OF_DAYS_IN_A_WEEK, DAYS } from "@/constants/date";
 import { cn } from "@/lib/utils";
 
 interface JournalWeeklyCalendarProps {
@@ -11,16 +12,6 @@ export default function JournalWeeklyCalendar({
   selectedDate,
   onClickSetSelectedDate,
 }: JournalWeeklyCalendarProps) {
-  const DAYS = [
-    { day: "일", key: "sunday" },
-    { day: "월", key: "monday" },
-    { day: "화", key: "theusday" },
-    { day: "수", key: "wednesday" },
-    { day: "목", key: "thursday" },
-    { day: "금", key: "friday" },
-    { day: "토", key: "saturday" },
-  ];
-
   const getCurrentWeek = () => {
     const currentDate = new Date();
     const currentDay = currentDate.getDay();
@@ -29,7 +20,7 @@ export default function JournalWeeklyCalendar({
     const startDate = new Date(currentDate.setDate(startDayOfWeek));
 
     const week = [];
-    for (let i = 0; i < 7; i++) {
+    for (let i = 0; i < COUNT_OF_DAYS_IN_A_WEEK; i++) {
       const date = new Date(startDate);
       date.setDate(startDate.getDate() + i);
       week.push(date);

--- a/components/JournalWeeklyCalendar.tsx
+++ b/components/JournalWeeklyCalendar.tsx
@@ -1,0 +1,77 @@
+interface JournalWeeklyCalendarProps {
+  today: Date;
+  selectDate: Date;
+  handleClickSetSelectDate: (date: Date) => void;
+}
+
+export default function JournalWeeklyCalendar({
+  today,
+  selectDate,
+  handleClickSetSelectDate,
+}: JournalWeeklyCalendarProps) {
+  const DAYS = [
+    { day: "일", key: "sunday" },
+    { day: "월", key: "monday" },
+    { day: "화", key: "theusday" },
+    { day: "수", key: "wednesday" },
+    { day: "목", key: "thursday" },
+    { day: "금", key: "friday" },
+    { day: "토", key: "saturday" },
+  ];
+
+  const getCurrentWeek = () => {
+    const currentDate = new Date();
+    const currentDay = currentDate.getDay();
+
+    const startDayOfWeek = currentDate.getDate() - currentDay;
+    const startDate = new Date(currentDate.setDate(startDayOfWeek));
+
+    const week = [];
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(startDate);
+      date.setDate(startDate.getDate() + i);
+      week.push(date);
+    }
+
+    return week;
+  };
+
+  return (
+    <div className="w-full animate-slide-up p-5 duration-100">
+      <div className="grid grid-cols-7 gap-4 rounded-lg text-center">
+        {DAYS.map((day, index) => {
+          const isWeekend = index === 0 || index === 6;
+
+          return (
+            <p
+              key={`${day.key}OfWeek`}
+              className={`leading-7 ${isWeekend ? "text-sub-text" : "text-main-text"}`}
+            >
+              {day.day}
+            </p>
+          );
+        })}
+      </div>
+      <div className="grid grid-cols-7 gap-4 rounded-lg text-center">
+        {getCurrentWeek().map((date) => {
+          return (
+            <div
+              key={`day_${date.getDate()}`}
+              className="flex w-full items-center justify-center"
+              onClick={() => {
+                handleClickSetSelectDate(date);
+              }}
+            >
+              <div
+                tabIndex={0}
+                className={`bold mt-[20px] flex h-9 w-9 cursor-pointer items-center justify-center rounded-md leading-7 transition-all duration-200 hover:bg-main-text hover:text-[#000] hover:transition ${date.getDate() === today.getDate() && "text-red-500 focus:text-[#000]"} ${selectDate.getDate() === date.getDate() && "bg-white text-[#000] focus:text-[#000]"}`}
+              >
+                {date.getDate()}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/JournalWeeklyCalendar.tsx
+++ b/components/JournalWeeklyCalendar.tsx
@@ -1,13 +1,13 @@
 interface JournalWeeklyCalendarProps {
   today: Date;
-  selectDate: Date;
-  handleClickSetSelectDate: (date: Date) => void;
+  selectedDate: Date;
+  onClickSetSelectedDate: (date: Date) => void;
 }
 
 export default function JournalWeeklyCalendar({
   today,
-  selectDate,
-  handleClickSetSelectDate,
+  selectedDate,
+  onClickSetSelectedDate,
 }: JournalWeeklyCalendarProps) {
   const DAYS = [
     { day: "일", key: "sunday" },
@@ -59,12 +59,12 @@ export default function JournalWeeklyCalendar({
               key={`day_${date.getDate()}`}
               className="flex w-full items-center justify-center"
               onClick={() => {
-                handleClickSetSelectDate(date);
+                onClickSetSelectedDate(date);
               }}
             >
               <div
                 tabIndex={0}
-                className={`bold mt-[20px] flex h-9 w-9 cursor-pointer items-center justify-center rounded-md leading-7 transition-all duration-200 hover:bg-main-text hover:text-[#000] hover:transition ${date.getDate() === today.getDate() && "text-red-500 focus:text-[#000]"} ${selectDate.getDate() === date.getDate() && "bg-white text-[#000] focus:text-[#000]"}`}
+                className={`bold mt-[20px] flex h-9 w-9 cursor-pointer items-center justify-center rounded-md leading-7 transition-all duration-200 hover:bg-main-text hover:text-[#000] hover:transition ${date.getDate() === today.getDate() && "text-red-500 focus:text-[#000]"} ${selectedDate.getDate() === date.getDate() && "bg-white text-[#000] focus:text-[#000]"}`}
               >
                 {date.getDate()}
               </div>

--- a/components/JournalWeeklyCalendar.tsx
+++ b/components/JournalWeeklyCalendar.tsx
@@ -59,7 +59,6 @@ export default function JournalWeeklyCalendar({
               }}
             >
               <div
-                tabIndex={0}
                 className={cn(
                   "bold mt-[20px] flex h-9 w-9 cursor-pointer items-center justify-center rounded-md leading-7 transition-all duration-200 hover:bg-main-text hover:text-[#000] hover:transition",
                   selectedDate.getDate() === date.getDate() &&

--- a/constants/date.ts
+++ b/constants/date.ts
@@ -2,3 +2,15 @@ export const yearRange = {
   start: 1940,
   end: new Date().getFullYear() + 1,
 };
+
+export const DAYS = [
+  { day: "일", key: "sunday" },
+  { day: "월", key: "monday" },
+  { day: "화", key: "theusday" },
+  { day: "수", key: "wednesday" },
+  { day: "목", key: "thursday" },
+  { day: "금", key: "friday" },
+  { day: "토", key: "saturday" },
+];
+
+export const COUNT_OF_DAYS_IN_A_WEEK = 7;


### PR DESCRIPTION
# 📌 작업 내용

style #50 `📄 page.tsx` 에서 정의된 Props를 공통으로 받아 달력을 컨트롤 할 수 있도록 구현

아래 코드를 `📄 page.tsx`에 `📋 복사/붙여넣기` 하여 작성된 컴포넌트를 확인할 수 있습니다.

```typescript
"use client";
import JournalWeeklyCalendar from "@/components/JournalWeeklyCalendar";
import { useState } from "react";

const TODAY_DATE = new Date();

export default function Home() {
  const [selectedDate, setSelectedDate] = useState(new Date());

  const handleClickSetSelectedDate = (date: Date) => {
    setSelectedDate(date);
  };

  return (
    <JournalWeeklyCalendar
      today={TODAY_DATE}
      selectedDate={selectedDate}
      onClickSetSelectedDate={handleClickSetSelectedDate}
    />
  );
}
```
<img width="1018" alt="스크린샷 2024-09-15 오후 6 02 39" src="https://github.com/user-attachments/assets/5456991a-6729-4df2-9502-6ae4530215f1">


# 🚦 특이 사항

기존 네이밍을 사용하였으나 마찬가지로 해당 컴포넌트에서는 onClick안에서 함수를 호출하여  날짜변경 함수를 사용함으로 해당 컴포넌트에서는 handle 접두사를 사용하였습니다.


<!-- close 할 이슈 번호 입력 -->

close #52 
