### PR TITLE
style: 운동 종목을 선택할 수 있는 `ExerciseCategorySelect` 공통 컴포넌트 구현

### DIFF
--- a/components/ExerciseCategorySelect/BodyPartPicker.tsx
+++ b/components/ExerciseCategorySelect/BodyPartPicker.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { Heart } from "lucide-react";
+import { useStorageStore } from "@/stores/useStorageStore";
+import { cn } from "@/lib/utils";
+import { useExerciseCategorySelectStore } from "@/stores/useExerciseCategorySelectStore";
+import { Button } from "../ui/button";
+
+interface BodyPartPickerProps {
+  className?: string;
+}
+
+export default function BodyPartPicker({ className }: BodyPartPickerProps) {
+  const userType = useStorageStore((state) => state.userType);
+  const bodyPart = useExerciseCategorySelectStore((state) => state.bodyPart);
+  const setBodyPart = useExerciseCategorySelectStore(
+    (state) => state.setBodyPart,
+  );
+  const [isLiked, setIsLiked] = useState(false);
+
+  const handleClickToggleIsLike = () => {
+    setIsLiked((prev) => !prev);
+  };
+
+  const resolveColorByUserType = () => {
+    return isLiked
+      ? userType === "Trianer"
+        ? "#5065ff"
+        : "#d5ff76"
+      : "#3e3e3e";
+  };
+
+  return (
+    <div className={className}>
+      <div className="flex items-center gap-1">
+        <Button
+          className="rounded-2xl bg-third-bg"
+          onClick={handleClickToggleIsLike}
+        >
+          <Heart color="#9e9e9e" fill={resolveColorByUserType()} />
+        </Button>
+        {bodyPart.map(({ name, isChecked, id }) => (
+          <Button
+            key={id}
+            className={cn(
+              "rounded-2xl bg-third-bg",
+              userType === "Trainer"
+                ? `hover:bg-primary-trainer hover:text-third-text ${isChecked && "bg-primary-trainer text-third-text"}`
+                : `hover:bg-primary-user hover:text-third-text ${isChecked && "bg-primary-user text-third-text"}`,
+            )}
+            onClick={() => setBodyPart(name)}
+          >
+            {name}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ExerciseCategorySelect/ExcerciseItem.tsx
+++ b/components/ExerciseCategorySelect/ExcerciseItem.tsx
@@ -3,7 +3,7 @@ import { Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface ExcerciseItemProps {
-  className: string;
+  className?: string;
   excercise: string;
   favorite: boolean;
   select: boolean;

--- a/components/ExerciseCategorySelect/ExerciseList.tsx
+++ b/components/ExerciseCategorySelect/ExerciseList.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { useExerciseCategorySelectStore } from "@/stores/useExerciseCategorySelectStore";
+import ExcerciseItem from "./ExcerciseItem";
+
+export default function ExerciseList() {
+  const selectedBodyPart = useExerciseCategorySelectStore(
+    (state) => state.selectedBodyPart,
+  );
+  const [excercises, setExcercises] = useState<string[]>([]);
+  const DYMMY_FAVORITE = [0, 2];
+  const DUMMY_DATA = [
+    {
+      id: 0,
+      name: "벤치 프레스",
+    },
+    {
+      id: 1,
+      name: "덤벨 벤치 프레스",
+    },
+    {
+      id: 2,
+      name: "덤벨 풀오버",
+    },
+    {
+      id: 3,
+      name: "펙덱 플라이",
+    },
+    {
+      id: 4,
+      name: "푸쉬엄",
+    },
+  ];
+
+  const handleClickSetExcercise = (name: string) => {
+    setExcercises((previousData) => {
+      if (previousData.includes(name)) {
+        return previousData.filter((excercise) => excercise !== name);
+      } else {
+        return [...previousData, name];
+      }
+    });
+  };
+
+  return (
+    <div className="flex h-80 w-full flex-col items-center gap-1 overflow-y-auto">
+      <p className="mb-1 w-full font-bold">{selectedBodyPart}</p>
+      {DUMMY_DATA.map(({ id, name }) => (
+        <ExcerciseItem
+          key={id}
+          excercise={name}
+          favorite={DYMMY_FAVORITE.includes(id)}
+          select={excercises.includes(name)}
+          onClickSetExcercise={handleClickSetExcercise}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/ExerciseCategorySelect/Header.tsx
+++ b/components/ExerciseCategorySelect/Header.tsx
@@ -1,0 +1,29 @@
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface HeaderProps {
+  className?: string;
+  setClose: () => void;
+}
+
+export default function Header({ className, setClose }: HeaderProps) {
+  const handleClickCloseExerciseCategorySelect = () => {
+    setClose();
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative flex w-full items-center justify-center font-bold",
+        className,
+      )}
+    >
+      <p className="text-xl">운동 추가</p>
+      <X
+        size={32}
+        className="absolute right-3"
+        onClick={handleClickCloseExerciseCategorySelect}
+      />
+    </div>
+  );
+}

--- a/components/ExerciseCategorySelect/SelectedExerciseCategories.tsx
+++ b/components/ExerciseCategorySelect/SelectedExerciseCategories.tsx
@@ -34,7 +34,7 @@ export default function SelectedExerciseCategories({
         {DUMMY_DATA.map(({ exerciseType }) => (
           <Badge
             className={cn(
-              "gap-1 whitespace-nowrap rounded-xl bg-sub-bg px-3 py-2",
+              "gap-1 whitespace-nowrap rounded-xl bg-third-bg px-3 py-2",
               userType === "Trainer"
                 ? "hover:bg-primary-trainer hover:text-third-text"
                 : "hover:bg-primary-user hover:text-third-text",

--- a/components/ExerciseCategorySelect/SelectedExerciseCategories.tsx
+++ b/components/ExerciseCategorySelect/SelectedExerciseCategories.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useStorageStore } from "@/stores/useStorageStore";
+import { Badge } from "../ui/badge";
+
+interface SelectedExerciseTypeProps {
+  className?: string;
+}
+
+export default function SelectedExerciseCategories({
+  className,
+}: SelectedExerciseTypeProps) {
+  const userType = useStorageStore((state) => state.userType);
+  const [DUMMY_DATA, setDUMMY_DATA] = useState([
+    { exerciseType: "벤치프레스" },
+    { exerciseType: "랫풀다운" },
+    { exerciseType: "데드리프트" },
+    { exerciseType: "스쿼트" },
+    { exerciseType: "바벨로우" },
+    { exerciseType: "레그프레스" },
+  ]);
+
+  const handleClickDeleteExercise = (exerciseName: string) => {
+    setDUMMY_DATA(
+      DUMMY_DATA.filter(({ exerciseType }) => exerciseType !== exerciseName),
+    );
+  };
+
+  return (
+    <div className={cn("flex max-w-full flex-col gap-2", className)}>
+      <p>선택한 운동 종목</p>
+      <div className="flex items-center gap-1 overflow-x-auto">
+        {DUMMY_DATA.map(({ exerciseType }) => (
+          <Badge
+            className={cn(
+              "gap-1 whitespace-nowrap rounded-xl bg-sub-bg px-3 py-2",
+              userType === "Trainer"
+                ? "hover:bg-primary-trainer hover:text-third-text"
+                : "hover:bg-primary-user hover:text-third-text",
+            )}
+            key={exerciseType}
+          >
+            {exerciseType}
+            <X
+              size={16}
+              onClick={() => handleClickDeleteExercise(exerciseType)}
+            />
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ExerciseCategorySelect/index.tsx
+++ b/components/ExerciseCategorySelect/index.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useStorageStore } from "@/stores/useStorageStore";
+import { cn } from "@/lib/utils";
+import { Button } from "../ui/button";
+import { SearchBar as ExerciseSearchBar } from "../SearchBar";
+import BodyPartPicker from "./BodyPartPicker";
+import ExerciseList from "./ExerciseList";
+import Header from "./Header";
+import SelectedExerciseCategories from "./SelectedExerciseCategories";
+
+interface ExerciseCategorySelectProps {
+  className?: string;
+  setClose: () => void;
+}
+
+export default function ExerciseCategorySelect({
+  className,
+  setClose,
+}: ExerciseCategorySelectProps) {
+  const userType = useStorageStore((state) => state.userType);
+
+  return (
+    <div
+      className={cn(
+        "fixed bottom-0 left-0 flex h-auto w-full flex-col items-center gap-10 overflow-y-auto rounded-t-[50px] bg-[#252525] p-4",
+        className,
+      )}
+    >
+      <Header setClose={setClose} />
+      <ExerciseSearchBar placeholder="운동 종목을 검색해보세요!" />
+      <BodyPartPicker className="self-start" />
+      <SelectedExerciseCategories className="self-start" />
+      <ExerciseList />
+      <Button
+        className={cn(
+          "h-14 w-40 rounded-[20px]",
+          userType === "Trainer"
+            ? "bg-primary-trainer text-third-text"
+            : "bg-primary-user text-third-text",
+        )}
+      >
+        저장
+      </Button>
+    </div>
+  );
+}

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { ChangeEvent, InputHTMLAttributes, forwardRef, useState } from "react";
+import { Search, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useStorageStore } from "@/stores/useStorageStore";
+import { Input } from "./ui/input";
+
+interface SearchBarProps extends InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
+}
+
+export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
+  ({ className, ...props }, ref) => {
+    const userType = useStorageStore((state) => state.userType);
+    const [inputValue, setInputValue] = useState("");
+
+    const handleClickClearInputValue = () => {
+      setInputValue("");
+      if (ref && typeof ref === "object" && ref.current) {
+        ref.current.value = "";
+      }
+    };
+
+    const handleChangeInputValue = (event: ChangeEvent<HTMLInputElement>) => {
+      setInputValue(event.target.value);
+    };
+
+    return (
+      <div className={cn("relative w-full", className)}>
+        <Input
+          ref={ref}
+          value={inputValue}
+          onChange={handleChangeInputValue}
+          className="h-[46px] w-full rounded-[10px] border-none bg-third-bg px-10 text-main-text"
+          {...props}
+        />
+        <Search
+          className="absolute left-3 top-1/2 z-10 -translate-y-1/2 transform"
+          color={userType === "Trainer" ? "#5065ff" : "#d5ff76"}
+        />
+        {inputValue && (
+          <X
+            size={16}
+            className="absolute right-3 top-1/2 z-10 -translate-y-1/2 transform cursor-pointer"
+            onClick={handleClickClearInputValue}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+SearchBar.displayName = "SearchBar";

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-300",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
+        secondary:
+          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
+        destructive:
+          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80",
+        outline: "text-slate-950 dark:text-slate-50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/stores/useExerciseCategorySelectStore.ts
+++ b/stores/useExerciseCategorySelectStore.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+
+interface BodyPartStateType {
+  name: string;
+  isChecked: boolean;
+  id: number;
+}
+
+interface ExerciseCategorySelectStoreType {
+  bodyPart: BodyPartStateType[];
+  setBodyPart: (bodyPart: string) => void;
+  selectedBodyPart: string;
+}
+
+export const useExerciseCategorySelectStore =
+  create<ExerciseCategorySelectStoreType>((set) => ({
+    bodyPart: [
+      { name: "가슴", isChecked: false, id: 1 },
+      { name: "등", isChecked: false, id: 2 },
+      { name: "어깨", isChecked: false, id: 3 },
+      { name: "하체", isChecked: false, id: 4 },
+      { name: "팔", isChecked: false, id: 5 },
+    ],
+    setBodyPart: (bodyName: string) =>
+      set((state) => {
+        const bodyPartCopy = [...state.bodyPart];
+
+        bodyPartCopy.forEach(({ name, isChecked }, index) => {
+          if (isChecked) bodyPartCopy[index].isChecked = false;
+          if (bodyName === name) {
+            bodyPartCopy[index].isChecked = !bodyPartCopy[index].isChecked;
+          }
+        });
+
+        const selectedBody =
+          bodyPartCopy.find(({ isChecked }) => isChecked)?.name || "";
+
+        return { bodyPart: bodyPartCopy, selectedBodyPart: selectedBody };
+      }),
+    selectedBodyPart: "",
+  }));


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->
<img width="391" alt="image" src="https://github.com/user-attachments/assets/a072c4d5-a3e4-46fd-b8cb-91d54db211c4">

- [x] 해당 컴포넌트의 역할과 해당 컴포넌트를 닫을 수 있는 `Header` 컴포넌트 구현
- [x] 운동 한 신체 부위를 선택할 수 있는 `BodyPartPicker` 컴포넌트 구현
- [x] 신체 부위에 해당하는 운동 종목을 선택하면 나타나는 `SelectedExerciseCategories` 컴포넌트 구현
- [x] 운동 종목을 선택할 수 있도록 나타내는 `ExerciseList` `ExerciseItem` 컴포넌트 구현
- [ ] 저장 버튼은 인터랙션 구현 X (API 스펙 나온 이후 구현할 예정) 
- [x] 신체 부위별 상태는 형제 요소끼리 상태를 공유해야하기 때문에 전역 상태로 관리하였습니다. 부모 컴포넌트에서 관리해도 무방하지만, 부모 컴포넌트에서 관리하다보면 코드가 길어지고 복잡해질 것이라 예상되어 부모 컴포넌트에서 상태를 관리하지 않았습니다. 아마 운동 종목 관련 상태도 운동 일지 작성에서 상태를 참조해야하기 때문에 전역 상태로 관리하는 것이 복잡성을 줄일 수 있을 것이라고 예상합니다.

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

- 컴포넌트 전체적인 구조에 대해 피드백 부탁드립니다.
- 컴포넌트명, 함수명 등 전체적인 네이밍에 대한 피드백 부탁드립니다.
- 현재 코드보다 더 나은 방안이 보이신다면 피드백 부탁드립니다.

<!-- close 할 이슈 번호 입력 -->

close #60 
