### PR TITLE
style: 피드백 작성 안내, 작업 종료 경고 문구를 나타내는 `Drawer` 컴포넌트 구현

### DIFF
--- a/components/Drawer/ExitConfirmation.tsx
+++ b/components/Drawer/ExitConfirmation.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+
+interface ExitConfirmationProps {
+  className?: string;
+  type: "exercise" | "diet";
+}
+
+export default function ExitConfirmation({
+  className,
+  type,
+}: ExitConfirmationProps) {
+  return (
+    <div
+      className={cn(
+        "flex w-full flex-col items-center justify-center",
+        className,
+      )}
+    >
+      <p className="text-xl">
+        {type === "exercise" ? "운동" : "식단"} 일지 작성에서 나가시겠어요?
+      </p>
+      <p className="text-sub-text">기록한 내용이 사라져요</p>
+    </div>
+  );
+}

--- a/components/Drawer/ExitOrCancelButtons.tsx
+++ b/components/Drawer/ExitOrCancelButtons.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+import { useStorageStore } from "@/stores/useStorageStore";
+import { Button } from "../ui/button";
+
+interface ExitOrCancelButtonsProps {
+  className?: string;
+  onClickCloseDrawer: () => void;
+}
+
+export default function ExitOrCancelButtons({
+  className,
+  onClickCloseDrawer,
+}: ExitOrCancelButtonsProps) {
+  const userType = useStorageStore((state) => state.userType);
+
+  return (
+    <div
+      className={cn("flex w-full items-center justify-center gap-3", className)}
+    >
+      <Button
+        onClick={onClickCloseDrawer}
+        className={cn(
+          "h-14 w-40 rounded-[20px] bg-transparent font-bold",
+          userType === "Trainer"
+            ? "border border-primary-trainer hover:bg-primary-trainer hover:text-third-text"
+            : "border border-primary-user hover:bg-primary-user hover:text-third-text",
+        )}
+      >
+        취소
+      </Button>
+      <Button
+        className={cn(
+          "h-14 w-40 rounded-[20px] bg-transparent font-bold",
+          userType === "Trainer"
+            ? "border border-primary-trainer hover:bg-primary-trainer hover:text-third-text"
+            : "border border-primary-user hover:bg-primary-user hover:text-third-text",
+        )}
+      >
+        나가기
+      </Button>
+    </div>
+  );
+}

--- a/components/Drawer/GuideFeedback.tsx
+++ b/components/Drawer/GuideFeedback.tsx
@@ -1,0 +1,20 @@
+import { MessageSquare } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface GuideFeedbackProps {
+  className?: string;
+}
+
+export default function GuideFeedback({ className }: GuideFeedbackProps) {
+  return (
+    <div
+      className={cn(
+        "flex w-full flex-col items-center justify-center gap-3",
+        className,
+      )}
+    >
+      <MessageSquare size={30} />
+      <p>아래에 피드백을 작성해주세요</p>
+    </div>
+  );
+}

--- a/components/Drawer/WriteFeedback.tsx
+++ b/components/Drawer/WriteFeedback.tsx
@@ -1,0 +1,30 @@
+import { forwardRef } from "react";
+import { CircleArrowUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Textarea } from "../ui/textarea";
+
+interface WriteFeedbackProps {
+  className?: string;
+  onClickSendFeedback: () => void;
+}
+
+const WriteFeedback = forwardRef<HTMLTextAreaElement, WriteFeedbackProps>(
+  ({ className, onClickSendFeedback }, ref) => {
+    return (
+      <div className={cn("relative w-full", className)}>
+        <Textarea
+          ref={ref}
+          className="w-full rounded-[10px] bg-third-bg p-3 pr-7"
+        />
+        <CircleArrowUp
+          onClick={onClickSendFeedback}
+          className="absolute bottom-2 right-2"
+        />
+      </div>
+    );
+  },
+);
+
+WriteFeedback.displayName = "WriteFeedback";
+
+export default WriteFeedback;

--- a/components/Drawer/index.tsx
+++ b/components/Drawer/index.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { ReactNode, useRef } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+import useOutsideClick from "@/hooks/useOutsideClick";
+import GuideFeedback from "./GuideFeedback";
+import WriteFeedback from "./WriteFeedback";
+import ExitConfirmation from "./ExitConfirmation";
+import ExitOrCancelButtons from "./ExitOrCancelButtons";
+
+interface DrawerType {
+  className?: string;
+  children: ReactNode;
+}
+
+interface DrawerContainerProps extends DrawerType {
+  isOpen: boolean;
+  onClickCloseDrwaer: () => void;
+}
+
+function DrawerContainer({
+  className,
+  isOpen,
+  onClickCloseDrwaer,
+  children,
+}: DrawerContainerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  useOutsideClick(drawerRef, onClickCloseDrwaer);
+
+  if (!isOpen) return;
+
+  return createPortal(
+    <div
+      ref={drawerRef}
+      className={cn(
+        "fixed bottom-0 z-10 flex w-full flex-col gap-10 rounded-t-[50px] bg-sub-bg px-5 py-10",
+        className,
+      )}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}
+
+interface HeaderProps extends DrawerType {}
+
+function Header({ className, children }: HeaderProps) {
+  return <div className={cn("w-full", className)}>{children}</div>;
+}
+
+interface ContentProps extends DrawerType {}
+
+function Content({ className, children }: ContentProps) {
+  return <div className={cn("w-full", className)}>{children}</div>;
+}
+
+const Drawer = Object.assign(DrawerContainer, {
+  Header,
+  Content,
+  GuideFeedback,
+  WriteFeedback,
+  ExitConfirmation,
+  ExitOrCancelButtons,
+});
+
+export default Drawer;


### PR DESCRIPTION
# 📌 작업 내용

<!-- 구현 내용 및 작업 했던 내역, 사진 및 동영상 선택적으로 첨부 -->

<img width="250" alt="image" src="https://github.com/user-attachments/assets/66857b92-c8d7-4ca6-aa81-99a486cbafc4">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/edcd8eb6-13e8-43dc-ac07-1ae4995494f7">

- [x] 합성 컴포넌트 구조로 `Drawer` 컴포넌트의 컨테이너, `Header`, `Content` 구현
- [x] Drawer 컴포넌트 내부의 자식요소로 들어갈 `작업 종료 경고 안내 컴포넌트`, `작업 종료 선택 여부 버튼`, `피드백 안내 문구`, `피드백 작성란` 컴포넌트 구현
- [x] `Drawer` 컴포넌트의 생성 및 제거 권한은 `Drawer` 컴포넌트를 사용하는 컴포넌트에게 있습니다. 사용하는 곳에서 boolean 상태를 설정하고 이를 `isOpen`, `onClickCloseDrawer` props를 사용하여 이를 컨트롤 할 수 있습니다.
- [ ] 작업 종료하고 나가기, 피드백 작성 후 전송은 아직 구현하지 않았습니다. API 스펙이 나온 뒤에 구현할 예정입니다.  

# 🚦 특이 사항

<!-- 주의 깊게 봐야하는 PR 포인트 & 말하고 싶은 점 -->

- 합성 컴포넌트 구조에 대한 피드백 부탁드립니다.
- 현재 Header, Content는 Index 내부에 위치하고 있습니다. 자식 요소를 담을 그릇이라 생각하여 index에 함께 위치하도록 두었는데 해당 구조가 적절한지 의견 부탁드립니다.
- 컴포넌트명, 함수 및 변수명 피드백 부탁드립니다.
- 스타일링은 아직 크게 신경 쓰지 않으셔도 될 것 같습니다. 아직 변경의 여지가 많기 때문에 전체적인 틀 위주로 보시면 될 것 같습니다.

<!-- close 할 이슈 번호 입력 -->

close #64
