### PR TITLE
style: 유저의 상세 정보를 조회하는 페이지 구현

### DIFF
--- a/app/(trainer)/trainer/user-profile/UserProfileView.tsx
+++ b/app/(trainer)/trainer/user-profile/UserProfileView.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { ArrowLeft } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
+import { useParams } from "next/navigation";
+
+interface UserProfileViewProps {
+  profileImageUrl: string;
+  userName: string;
+  birthDate: string;
+  height: string;
+  weight: string;
+  gender: string;
+  purpose: string;
+}
+
+function renderUserInfo(label: string, value: string) {
+  return (
+    <div className="flex h-12 items-center justify-between">
+      <span>{label}</span>
+      <span className="text-sub-text">{value}</span>
+    </div>
+  );
+}
+export default function UserProfileView({
+  profileImageUrl,
+  userName,
+  birthDate,
+  height,
+  weight,
+  gender,
+  purpose,
+}: UserProfileViewProps) {
+  return (
+    <main className="w-full">
+      <section className="relative flex h-12 items-center">
+        <ArrowLeft size={32} className="absolute left-0 cursor-pointer" />
+        <h1 className="mx-auto text-xl">{userName}</h1>
+      </section>
+      <article className="mt-[44px] flex items-center justify-center">
+        <Avatar className="h-[108px] w-[108px]">
+          <AvatarImage src={profileImageUrl} className="rounded-lg" />
+          <AvatarFallback></AvatarFallback>
+        </Avatar>
+      </article>
+
+      <section className="mt-[45px]">
+        <span className="text-lg">회원정보</span>
+        <div className="mt-[27px] grid grid-rows-2 divide-y divide-[#303030]">
+          {[
+            ["생년월일", birthDate],
+            ["키", height],
+            ["몸무게", weight],
+            ["성별", gender],
+            ["운동목적", purpose],
+          ].map(([label, value]) => renderUserInfo(label, value))}
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
# 📌 작업 내용

트레이너가 회원의 상세정보를 원하는 페이지로 넘어가면 보여지는 페이지를 구현

<img width="596" alt="스크린샷 2024-10-01 오후 8 31 36" src="https://github.com/user-attachments/assets/422b0f34-de97-44ea-9151-f411555e0750">

다음 코드를 page.tsx에 작성하여 페이지를 확인할 수 있습니다.

```typescript
import UserProfileView from "./UserProfileView";

export default function UserInformation() {
  return (
    <UserProfileView
      profileImageUrl="https://github.com/shadcn.png"
      userName="홍길동"
      birthDate="1990-01-01"
      height="180cm"
      weight="78kg"
      gender="남자"
      purpose="다이어트"
    />
  );
}
```

🚧 현재 테스트 구현을 위해 props로 넘겨왔지만, 아마 완성 단계에서는 useParams를 통해 선택한 회원의 데이터를 가져와서 해당 유저데이터를 서버로 던져서 가져와질 것을 예상합니다.

🚧 데이터의 형식이 다양한데, 생년월일은 Date, 운동목적이 배열로 들어올 경우 렌더링하는 방법에 수정이 필요할 것으로 보입니다.


# 🚦 특이 사항

구조가 적절해 보이는지 확인 부탁드리겠습니다.



<!-- close 할 이슈 번호 입력 -->

close #62 
